### PR TITLE
add draft PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Reason for pull request
+
+Please provide a short description of the reason for the change, or link a specific Github issue.
+
+## What has been changed?
+
+Please provide a short description of what has been changed.
+
+## Other useful information
+
+If any, please provide any further useful info.
+
+## Checklist
+
+- [ ] I've included all the commits I intended to in this PR 
+- [ ] I've built and tested this branch and there were no new warnings or errors 


### PR DESCRIPTION
Just because I like recursion. Which this sort of is....

## Reason for pull request

I think it would be nice to have a PR template. Especially to help external collaborators, but also so we behave better with PRs ourselves. This will make us tick a box to say we've built and tested.

## What has been changed?

I've added this draft PR template to .github 

## Other useful information

I shall not. I refuse

## Checklist

- [x] I've included all the commits I intended to in this PR 
- [x] I've built and tested this branch and there were no new warnings or errors 