### PR TITLE
fix old website links fix #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Aire Documentation
 
-This is the repository for the documentation for the University of Leeds Aire HPC system. It is managed by the University of Leeds [Research Computing Team.](https://arc.leeds.ac.uk/profile_type/team/)
+This is the repository for the documentation for the University of Leeds Aire HPC system. It is managed by the University of Leeds [Research Computing Team.](https://arc.leeds.ac.uk/team/)
 
 ## Contributing to the documentation
 We welcome all contributions to this project via GitHub issues and pull requests. Please follow the guidelines on the [`CONTRIBUTING.md` file](CONTRIBUTING.md) to make sure your contributions can be easily integrated in the project. Edits must be approved by at least one user from the arcdocs group (generally RSEs & RIEs at Leeds). For larger issues that can't be solved quickly, or require greater input, please raise an Issue in the "Issues" tab. 

--- a/book/getting_started/request_account.md
+++ b/book/getting_started/request_account.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-The HPC systems run the Linux operating system. You should be familiar with using Linux at the command line level in order to run tasks. We provide periodic training [HPC0: Introduction to Linux for HPC](https://arc.leeds.ac.uk/courses/hpc0-introduction-to-linux-for-hpc/) to help you get started. Much of the work done on HPC systems is scripted to automate many tasks, so understanding the basics is important and highly beneficial.
+The HPC systems run the Linux operating system. You should be familiar with using Linux at the command line level in order to run tasks. We provide periodic training [HPC0: Introduction to Linux for HPC](https://arc.leeds.ac.uk/knowledge-centre/courses/hpc0/) to help you get started. Much of the work done on HPC systems is scripted to automate many tasks, so understanding the basics is important and highly beneficial.
 
 ## User Accounts
 

--- a/book/getting_started/start.md
+++ b/book/getting_started/start.md
@@ -19,7 +19,7 @@ In general we can support most areas where there are long runs that take hours, 
 
 ## How to get started with HPC?
 
-Before diving into HPC, it's beneficial to have discussions with your colleagues and supervisor to understand how HPC can best support your research. They can provide valuable insights and advice based on their experience. If you're new to HPC, consider taking introductory training courses such as [HPC0: Introduction to Linux for HPC](https://arc.leeds.ac.uk/courses/hpc0-introduction-to-linux-for-hpc/) and [HPC1: Introduction to High Performance Computing](https://arc.leeds.ac.uk/courses/hpc1-introduction-to-high-performance-computing/) to build a solid foundation. Additionally, explore self-help resources and join relevant teams or forums where you can ask questions and share knowledge with other HPC users. These steps will help you make the most of the HPC resources available to you.
+Before diving into HPC, it's beneficial to have discussions with your colleagues and supervisor to understand how HPC can best support your research. They can provide valuable insights and advice based on their experience. If you're new to HPC, consider taking introductory training courses such as [HPC0: Introduction to Linux for HPC](https://arc.leeds.ac.uk/knowledge-centre/courses/hpc0/) and [HPC1: Introduction to High Performance Computing](https://arc.leeds.ac.uk/knowledge-centre/courses/hpc1/) to build a solid foundation. Additionally, explore self-help resources and join relevant teams or forums where you can ask questions and share knowledge with other HPC users. These steps will help you make the most of the HPC resources available to you.
 
 <!-- ## Table of Contents
 


### PR DESCRIPTION
## Reason for pull request

Following a recent update to the main ARC website structure, several links in the Aire documentation that point to https://arc.leeds.ac.uk/ became invalid. This pull request updates those broken links to their new locations.

## What has been changed?

- Updated all broken occurrences of https://arc.leeds.ac.uk/ in the Aire documentation to reflect the new website structure.
- Fixed links to:
  - HPC0: Introduction to Linux for HPC
  - HPC1: Introduction to High Performance Computing
- Fixed an additional broken link to the team profile page.
- Searched the documentation base for all occurrences of `arc.leeds.ac.uk` and updated every broken link identified.

These changes are limited to link corrections only.

## Other useful information

This PR is a maintenance update to keep documentation consistent with the current ARC website structure. While every effort was made to capture all affected links, additional broken links may exist and can be corrected separately if identified.

This PR fixes the issue #12 

## Checklist

- [x] I've included all the commits I intended to in this PR 
- [x] I've built and tested this branch and there were no new warnings or errors 