### PR TITLE
Add notes for config path set-up

### DIFF
--- a/book/usage/file_data_management/data_transfer.md
+++ b/book/usage/file_data_management/data_transfer.md
@@ -69,7 +69,7 @@ The following guidance has been adapted from the [Globus documentation (Linux in
    ```bash
    $ tar xzf globusconnectpersonal-latest.tgz
    # this will produce a versioned globusconnectpersonal directory
-   # replace `x.y.z` in the line below with the version number you see
+   # replace `x.y.z` in the line below with the version number you see, or use tab complete
    $ cd globusconnectpersonal-x.y.z
    ```
 
@@ -79,7 +79,7 @@ The following guidance has been adapted from the [Globus documentation (Linux in
    $ ./globusconnectpersonal -setup --no-gui
    ```
 
-   This will launch Globus, and your terminal should provide you with a URL to visit on your local machine to complete set-up (including University of Leeds SSO); you will then receive a key to copy and past back into the command line on Aire. Please see the [Globus documentation](https://docs.globus.org/globus-connect-personal/install/linux/#running_with_no_gui) for further details.
+   This will launch Globus, and your terminal should provide you with a URL to visit on your local machine to complete set-up (including University of Leeds SSO); you will then receive a key to copy and past back into the command line on Aire. You will then need to set a name for this endpoint (e.g. Aire). Please see the [Globus documentation](https://docs.globus.org/globus-connect-personal/install/linux/#running_with_no_gui) for further details.
 4. You can close Globus once set-up is complete.
 5. Modify or create the file `config-paths` (assuming you are still in the folder `globusconnectpersonal-x.y.z`) with your favourite text editor (this command will create the file if it doesn't already exist):
 
@@ -93,19 +93,21 @@ The following guidance has been adapted from the [Globus documentation (Linux in
    <path>,<sharing flag>,<R/W flag>
    ```
 
-   In your file, you'll see:
+   The nano command may create a new empty file, or you may already have this file, depending on the verison of Globus. If there is already content in this file, you'll see something like this:
 
    ```bash
    ~/,0,1
    ```
 
-   Which provides access to your home directory (`~/`), doesn't allow sharing (`0` as the sharing flag), and and allows read/write access (`1` as the R/W flag).
+   Which provides access to your home directory (`~/`), doesn't allow sharing (`0` as the sharing flag), and and allows read/write access (`1` as the R/W flag). Don't worry if the file is empty; just add the above line and save in order to access your home directory (or `~/some_directory/,0,1` for a sub-directory).
 
-   You can add `$SCRATCH` with the same permissions by adding the following line to the file and saving:
+   You can add also `$SCRATCH` with the same permissions by adding the following line to the file and saving:
 
    ```bash
    $/mnt/scratch/$USER,0,1
    ```
+
+   Or again, a sub-directory: `$/mnt/scratch/$USER/some_directory/,0,1`.
 
    Read more about [Managing Globus Connect Personal Directory Permissions via the Config File in the official documentation](https://docs.globus.org/globus-connect-personal/install/linux/#config-paths).
 

--- a/book/usage/file_data_management/data_transfer.md
+++ b/book/usage/file_data_management/data_transfer.md
@@ -79,7 +79,7 @@ The following guidance has been adapted from the [Globus documentation (Linux in
    $ ./globusconnectpersonal -setup --no-gui
    ```
 
-   This will launch Globus, and your terminal should provide you with a URL to visit on your local machine to complete set-up (including University of Leeds SSO); you will then receive a key to copy and past back into the command line on Aire. You will then need to set a name for this endpoint (e.g. `aire_endpoint` or something sensible). Please see the [Globus documentation](https://docs.globus.org/globus-connect-personal/install/linux/#running_with_no_gui) for further details.
+   This will launch Globus, and your terminal should provide you with a URL to visit on your local machine to complete set-up (including University of Leeds SSO); you will then receive a key to copy and paste back into the command line on Aire. You will then need to set a name for this endpoint (e.g. `aire_endpoint` or something sensible). Please see the [Globus documentation](https://docs.globus.org/globus-connect-personal/install/linux/#running_with_no_gui) for further details.
 4. You can close Globus once set-up is complete.
 5. Modify or create the file `config-paths` (assuming you are still in the folder `globusconnectpersonal-x.y.z`) with your favourite text editor (this command will create the file if it doesn't already exist):
 
@@ -99,7 +99,7 @@ The following guidance has been adapted from the [Globus documentation (Linux in
    ~/,0,1
    ```
 
-   Which provides access to your home directory (`~/`), doesn't allow sharing (`0` as the sharing flag), and and allows read/write access (`1` as the R/W flag). Don't worry if the file is empty; just add the above line and save in order to access your home directory (or `~/some_directory/,0,1` for a sub-directory).
+   Which provides access to your home directory (`~/`), doesn't allow sharing (`0` is the sharing flag), and and allows read/write access (`1` is the R/W flag). Don't worry if the file is empty; just add the above line and save in order to access your home directory (or `~/some_directory/,0,1` for a sub-directory).
 
    You can also add `$SCRATCH` with the same permissions by adding the following line to the file and saving:
 

--- a/book/usage/file_data_management/data_transfer.md
+++ b/book/usage/file_data_management/data_transfer.md
@@ -79,7 +79,7 @@ The following guidance has been adapted from the [Globus documentation (Linux in
    $ ./globusconnectpersonal -setup --no-gui
    ```
 
-   This will launch Globus, and your terminal should provide you with a URL to visit on your local machine to complete set-up (including University of Leeds SSO); you will then receive a key to copy and past back into the command line on Aire. You will then need to set a name for this endpoint (e.g. Aire). Please see the [Globus documentation](https://docs.globus.org/globus-connect-personal/install/linux/#running_with_no_gui) for further details.
+   This will launch Globus, and your terminal should provide you with a URL to visit on your local machine to complete set-up (including University of Leeds SSO); you will then receive a key to copy and past back into the command line on Aire. You will then need to set a name for this endpoint (e.g. `aire_endpoint` or something sensible). Please see the [Globus documentation](https://docs.globus.org/globus-connect-personal/install/linux/#running_with_no_gui) for further details.
 4. You can close Globus once set-up is complete.
 5. Modify or create the file `config-paths` (assuming you are still in the folder `globusconnectpersonal-x.y.z`) with your favourite text editor (this command will create the file if it doesn't already exist):
 
@@ -93,7 +93,7 @@ The following guidance has been adapted from the [Globus documentation (Linux in
    <path>,<sharing flag>,<R/W flag>
    ```
 
-   The nano command may create a new empty file, or you may already have this file, depending on the verison of Globus. If there is already content in this file, you'll see something like this:
+   The nano command may create a new empty file, or you may already have this file, depending on the version of Globus. If there is already content in this file, you'll see something like this:
 
    ```bash
    ~/,0,1
@@ -101,7 +101,7 @@ The following guidance has been adapted from the [Globus documentation (Linux in
 
    Which provides access to your home directory (`~/`), doesn't allow sharing (`0` as the sharing flag), and and allows read/write access (`1` as the R/W flag). Don't worry if the file is empty; just add the above line and save in order to access your home directory (or `~/some_directory/,0,1` for a sub-directory).
 
-   You can add also `$SCRATCH` with the same permissions by adding the following line to the file and saving:
+   You can also add `$SCRATCH` with the same permissions by adding the following line to the file and saving:
 
    ```bash
    $/mnt/scratch/$USER,0,1


### PR DESCRIPTION
Clarified instructions for setting up Globus Connect Personal, including version number handling and endpoint naming; also added note re creating config path file (as opposed to jsut editing)

## Reason for pull request

[Please provide a short description of the reason for the change, or link a specific Github issue.](https://github.com/arcdocs/aire/issues/3) 

## What has been changed?

Very minor edits to clarify creating new config path file for Globus, to ensure home dir and scratch are visible.

## Other useful information

This builds on a alrger PR by Tianyi that fixed errors in config paths and clarified lcoations for different commands, as per the issue https://github.com/arcdocs/aire/issues/3

## Checklist

- [X] I've included all the commits I intended to in this PR 
- [X] I've built and tested this branch and there were no new warnings or errors 

This PR will close the issue https://github.com/arcdocs/aire/issues/3