### PR TITLE
Add ga

### DIFF
--- a/.devcontainer/CODESPACE_WELCOME.md
+++ b/.devcontainer/CODESPACE_WELCOME.md
@@ -13,6 +13,8 @@ You can use `git` as you would locally, including pushing to the remote. You won
 You should automatically have an open terminal with the prompt `(arcdocs-aire-jb) root@codespaces-e8c8b0:/workspace#`.
 If not, open a new terminal with `Ctrl + Shift + '`; this terminal should already have the [`arcdocs-aire-jb` conda environment](../environment.yml) activated.
 
+Note: there may be a little delay before the environment begins to install.
+
 ### 1. Build the documentation
 
 ```bash
@@ -25,9 +27,17 @@ jupyter-book build book/
 python -m http.server -d book/_build/html
 ```
 
-Then visit the forwarded port 8000 in your browser. VSCode should prompt you to do this with a popup, providing a URL for you to visit (the rmeote-machine equivalent of [localhost:8000](http://localhost:8000/welcome.html)):
+Then visit the forwarded port 8000 in your browser. VSCode should prompt you to do this with a popup, providing a URL for you to visit (the remote-machine equivalent of [localhost:8000](http://localhost:8000/welcome.html)):
 
 ![alt text](open_in_browser.png)
+
+### 3. Make changes
+
+Ensure you create and swap to a new branch to store any changes, and test that your local build looks correct before opening a pull request:
+
+```bash
+git switch -c new-branch-name
+```
 
 ## Useful Commands
 

--- a/.devcontainer/CODESPACE_WELCOME.md
+++ b/.devcontainer/CODESPACE_WELCOME.md
@@ -36,7 +36,7 @@ Then visit the forwarded port 8000 in your browser. VSCode should prompt you to 
 Ensure you create and swap to a new branch to store any changes, and test that your local build looks correct before opening a pull request:
 
 ```bash
-git switch -c new-branch-name
+git switch -c <new-branch-name>
 ```
 
 ## Useful Commands

--- a/book/_config.yml
+++ b/book/_config.yml
@@ -3,7 +3,7 @@ title: Aire Documentation
 author: University of Leeds Research Computing Team
 logo: ./assets/img/logo/logo.png
 email: ask-rc@leeds.ac.uk
-copyright: "2025"
+copyright: "2026"
 
 # Auto-exclude files not in the toc
 only_build_toc_files        : true

--- a/book/_config.yml
+++ b/book/_config.yml
@@ -3,7 +3,7 @@ title: Aire Documentation
 author: University of Leeds Research Computing Team
 logo: ./assets/img/logo/logo.png
 email: ask-rc@leeds.ac.uk
-copyright: "2024"
+copyright: "2025"
 
 # Auto-exclude files not in the toc
 only_build_toc_files        : true
@@ -11,18 +11,6 @@ only_build_toc_files        : true
 # execute settings
 execute:
   execute_notebooks: auto
-
-# HTML-specific settings
-html:
-  analytics:
-    google_analytics_id       : "G-316J3DQCR9"  # A GA id that can be used to track book views.
-  favicon                   : "./assets/img/logo/favicon-32x32.png"  # A path to a favicon image
-  navbar_number_sections    : false  # Add a number to each section in your left navbar
-  home_page_in_navbar       : true  # Whether to include your home page in the left Navigation Bar
-  use_repository_button: true
-  use_issues_button: true
-  use_edit_page_button: true
-  baseurl                   : "https://arcdocs.leeds.ac.uk/aire"  # The base URL where your book will be hosted. Used for creating image previews and social links. e.g.: https://mypage.com/mybook/
 
 # Launch button settings
 launch_buttons:
@@ -47,3 +35,38 @@ parse:
     - deflist
     - html_admonition
     - colon_fence
+
+# HTML-specific settings
+html:
+  extra_footer: |
+      <p>
+      <a href="#" id="open_preferences_center">Update cookies preferences</a>
+      </p>
+      <!-- Cookie Consent by TermsFeed https://www.TermsFeed.com -->
+      <script type="text/javascript" src="//www.termsfeed.com/public/cookie-consent/4.2.0/cookie-consent.js" charset="UTF-8"></script>
+      <script type="text/javascript" charset="UTF-8">
+      document.addEventListener('DOMContentLoaded', function () {
+      cookieconsent.run({"notice_banner_type":"simple","consent_type":"express","palette":"dark","language":"en","page_load_consent_levels":["strictly-necessary"],"notice_banner_reject_button_hide":false,"preferences_center_close_button_hide":false,"page_refresh_confirmation_buttons":false,"website_name":"Aire User Documentation","website_privacy_policy_url":"https://comms.leeds.ac.uk/websites/policy-on-privacy-and-cookie-notices/"});
+      });
+      </script>
+
+      <!-- Google Analytics -->
+      <script type="text/plain" data-cookie-consent="tracking" async src="https://www.googletagmanager.com/gtag/js?id=G-RZDCG2LMBZ"></script>
+      <script type="text/plain" data-cookie-consent="tracking">
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-RZDCG2LMBZ');
+      </script>
+      <!-- end of Google Analytics-->
+
+      <noscript>Free cookie consent management tool by <a href="https://www.termsfeed.com/">TermsFeed Generator</a></noscript>
+      <!-- End Cookie Consent by TermsFeed https://www.TermsFeed.com -->
+  favicon                   : "./assets/img/logo/favicon-32x32.png"  # A path to a favicon image
+  navbar_number_sections    : false  # Add a number to each section in your left navbar
+  home_page_in_navbar       : true  # Whether to include your home page in the left Navigation Bar
+  use_repository_button: true
+  use_issues_button: true
+  use_edit_page_button: true
+  baseurl                   : "https://arcdocs.leeds.ac.uk/aire"  # The base URL where your book will be hosted. Used for creating image previews and social links. e.g.: https://mypage.com/mybook/

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -102,3 +102,4 @@ chapters:
   title: Contact Us
 - url: https://arc.leeds.ac.uk
   title: Research Computing Website
+- file: privacy_and_cookies

--- a/book/assets/img/GA.html
+++ b/book/assets/img/GA.html
@@ -1,0 +1,41 @@
+<!-- Script to add Google analytics. You can chnge the GA tag as needed. This wraps it in a cookie consent script -->
+
+<!-- Google tag (gtag.js) -->
+<!-- <script async src="https://www.googletagmanager.com/gtag/js?id=G-RZDCG2LMBZ"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-RZDCG2LMBZ');
+</script> -->
+
+<!-- Cookie Consent by TermsFeed https://www.TermsFeed.com -->
+<script type="text/javascript" src="//www.termsfeed.com/public/cookie-consent/4.2.0/cookie-consent.js" charset="UTF-8"></script>
+<script type="text/javascript" charset="UTF-8">
+document.addEventListener('DOMContentLoaded', function () {
+cookieconsent.run({"notice_banner_type":"simple","consent_type":"express","palette":"dark","language":"en","page_load_consent_levels":["strictly-necessary"],"notice_banner_reject_button_hide":false,"preferences_center_close_button_hide":false,"page_refresh_confirmation_buttons":false,"website_name":"Aire User Documentation","website_privacy_policy_url":"https://comms.leeds.ac.uk/websites/policy-on-privacy-and-cookie-notices/"});
+});
+</script>
+
+<!-- Google Analytics -->
+<script type="text/plain" data-cookie-consent="tracking" async src="https://www.googletagmanager.com/gtag/js?id=G-RZDCG2LMBZ"></script>
+<script type="text/plain" data-cookie-consent="tracking">
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-RZDCG2LMBZ');
+</script>
+<!-- end of Google Analytics-->
+
+<noscript>Free cookie consent management tool by <a href="https://www.termsfeed.com/">TermsFeed Generator</a></noscript>
+<!-- End Cookie Consent by TermsFeed https://www.TermsFeed.com -->
+
+
+
+
+
+<!-- Below is the link that users can use to open Preferences Center to change their preferences. Do not modify the ID parameter. Place it where appropriate, style it as needed. -->
+
+<!-- <a href="#" id="open_preferences_center">Update cookies preferences</a> -->

--- a/book/assets/img/GA.html
+++ b/book/assets/img/GA.html
@@ -14,7 +14,7 @@
 <script type="text/javascript" src="//www.termsfeed.com/public/cookie-consent/4.2.0/cookie-consent.js" charset="UTF-8"></script>
 <script type="text/javascript" charset="UTF-8">
 document.addEventListener('DOMContentLoaded', function () {
-cookieconsent.run({"notice_banner_type":"simple","consent_type":"express","palette":"dark","language":"en","page_load_consent_levels":["strictly-necessary"],"notice_banner_reject_button_hide":false,"preferences_center_close_button_hide":false,"page_refresh_confirmation_buttons":false,"website_name":"Aire User Documentation","website_privacy_policy_url":"https://comms.leeds.ac.uk/websites/policy-on-privacy-and-cookie-notices/"});
+cookieconsent.run({"notice_banner_type":"simple","consent_type":"express","palette":"dark","language":"en","page_load_consent_levels":["strictly-necessary"],"notice_banner_reject_button_hide":false,"preferences_center_close_button_hide":false,"page_refresh_confirmation_buttons":false,"website_name":"Aire User Documentation","website_privacy_policy_url":"https://arcdocs.leeds.ac.uk/aire/privacy_and_cookies.html"});
 });
 </script>
 

--- a/book/privacy_and_cookies.md
+++ b/book/privacy_and_cookies.md
@@ -27,7 +27,7 @@ Where we request personal data from you on our website you will be informed at t
 
 ## 5. Purpose of processing - automated collection of personal information
 
-When you access our web pages certain information your browser provides, including your IP address at the time, browser type, and potentially the address of the page you last visited, will be automatically recorded by the University [if externally hosted add details here of any collection carried out by the hosting provider]. This data may be used to aid detection in the event of a security breach. The legal basis for this processing is necessity to pursue our legitimate interests to keep our website secure. The University [if externally hosted add details here of any collection carried out by the hosting provider] retains this data in a form from which you may be identifiable for a period of up to one month.
+When you access our web pages certain information your browser provides, including your IP address at the time, browser type, and potentially the address of the page you last visited, will be automatically recorded by the University and GitHub. This data may be used to aid detection in the event of a security breach. The legal basis for this processing is necessity to pursue our legitimate interests to keep our website secure. The University and GitHub retains this data in a form from which you may be identifiable for a period of up to one month.
 
 ## 6. Third-party access
 

--- a/book/privacy_and_cookies.md
+++ b/book/privacy_and_cookies.md
@@ -1,0 +1,98 @@
+# Privacy and cookies
+
+Privacy notice for [Aire User Documentation](https://arcdocs.leeds.ac.uk/aire)
+This privacy notice has been updated in line with the General Data Protection Regulation. <a href="#" id="open_preferences_center">You can manage your cookie settings here. </a>
+
+
+## 1. Purpose of this Notice
+
+This Notice tells you how the University of Leeds (University) [add any other organisation here. For example if your website is hosted externally or if data is collected for us by an external organisation those details must be included here] will collect and use your personal data when you access this website. The University [see above regarding joint collection] is a “controller” of this personal data for the purposes of the data protection legislation. 
+Note that additional information will be provided where you are requested to enter personal information and this will vary between our various websites.  (Information will be provided through the relevant privacy notice for that website).
+It is important that you read this Notice together with any other privacy notice we provide on specific occasions when we are collecting or processing personal data about you so that you are fully aware of how and why we are using your data.  This Notice supplements the other notices and is not intended to override them.
+
+
+## 2. Changes to this Notice
+
+We keep the information provided in this Notice under review. This Notice may be updated from time to time. If we make any substantial updates, we will draw these to your attention.
+We will not use your personal data in any manner that is incompatible with the purpose for which the data were collected originally, unless we have obtained your consent to that additional use.
+
+## 3. Anything you are not clear about
+
+If there is anything you are unclear about, please contact our Data Protection Officer, who shall be happy to answer any queries you may have concerning this Notice or the way in which we process your personal data.
+The Data Protection Officer's contact details are provided at the end of this Notice.
+
+## 4. Purpose of processing your data
+
+Where we request personal data from you on our website you will be informed at that time of the purpose for which the data will be processed and how it will be processed, its legal basis for processing as well as any transfers to third parties.
+
+## 5. Purpose of processing - automated collection of personal information
+
+When you access our web pages certain information your browser provides, including your IP address at the time, browser type, and potentially the address of the page you last visited, will be automatically recorded by the University [if externally hosted add details here of any collection carried out by the hosting provider]. This data may be used to aid detection in the event of a security breach. The legal basis for this processing is necessity to pursue our legitimate interests to keep our website secure. The University [if externally hosted add details here of any collection carried out by the hosting provider] retains this data in a form from which you may be identifiable for a period of up to one month.
+
+## 6. Third-party access
+
+Your personal data that you have provided will not routinely be sent to third parties (unless notified - see 4. above).
+
+## 7. Data retention
+
+The University’s policies on retaining data for prospective and current students, staff and job applicants are detailed in our [data retention policy.](http://www.leeds.ac.uk/secretariat/documents/retention_policies.pdf)
+
+In other cases, for example, if you subscribe to news or events, any retention of data will be made clear at the point of collection.
+
+## 8. Cookies
+
+
+<a href="#" id="open_preferences_center">You can manage your cookie settings here. </a>
+
+Cookies are small text files that are placed on your device by websites that you visit.
+
+We use cookies for the following purposes:
+
+- Essential: To help our website function
+- Performance tracking: Track how our website is used and help us make improvements
+- Marketing: To inform targeted advertising.
+
+| Cookie Type | Cookie Name | Purpose | Information |
+|---|---|---|---|
+| Essential | cookieconsent_status | Determined whether or not the cookie popup has been accepted. | Persistent cookie. Expires after 12 months. |
+| Performance and advertising | __utma, __utmb, __utmc, __utmv, __utmz, __ga, __gat, __nid | These cookies are used to collect information about how visitors use our website. We use the information to compile reports and to help us improve the site. These cookies are also used to track users’ interests and then provide targeted advertising on other websites. The cookies collect information in an anonymous form, including the number of visitors to the site, where visitors have come to the site from and the pages they visited. | [Google privacy policy](https://policies.google.com/privacy?hl=en-GB&gl=uk), [Google analytics](https://support.google.com/analytics/answer/6004245), [Google analytics terms of service](https://www.google.com/analytics/terms/gb.html), [Google tag manager terms of service](https://www.google.com/analytics/tag-manager/use-policy/), [Universal Analytics opt-out browser add-on](https://tools.google.com/dlpage/gaoptout) |
+
+### Third party cookies and tracking
+
+If you share content from our website through other websites, for example Facebook or Twitter, cookies or a form of tracking may be used by these services and you need to manage your privacy via your account (and not through our site).
+
+### Manage your cookies and privacy
+
+You can opt out of non-essential cookies. <a href="#" id="open_preferences_center">You can manage your cookie settings here. </a>
+
+
+You can also manage your privacy settings, including cookies, through your browser settings.
+Further information about cookies can be found on the Information Commissioner's Office website.
+
+## 9. Your duty to inform us of changes
+
+It is important that the personal data the University holds about you is accurate and current. Please keep us informed if the personal data you have provided to us needs to be updated.
+[Contact us](http://www.leeds.ac.uk/info/5000/about/196/contact_us)
+
+## 10.  Your rights as a data subject
+
+Under the GDPR, in certain circumstances, you have the right to:
+
+- withdraw your consent to our processing of your personal data where that is the legal basis for such processing
+- access any of your personal data which we hold
+- have your personal data which we hold corrected if it is inaccurate
+- have any of your personal data which we hold erased
+- restrict the ways in which we process your personal data
+- object to our processing of your personal data
+- receive a copy of any of your personal data which we hold in a structured and commonly used machine-readable format
+- in certain cases not be subject to a decision based solely on automated decision making
+- lodge a complaint with a supervisory authority
+
+# 11.  Queries and complaints
+
+If you have any queries or concerns relating to this privacy notice or the way your data is being processed through this website then please contact the University’s Data Protection Officer, Alice Temple on dpo@leeds.ac.uk or by post to University of Leeds, 11.72 EC Stoner Building, Leeds LS2 9JT, UK.
+
+The University’s main telephone number is +44 (0) 113 2431751.
+
+The UK’s regulator for the DPA and GDPR is the Information Commissioner’s Office (ICO). The University is registered as a Data Controller with the ICO
+Should you be dissatisfied with our handling of your concerns you have the right to complain to a supervisory authority. In the case of the UK this is the Information Commissioner’s Office and details can be found at https://ico.org.uk.


### PR DESCRIPTION
## Reason for pull request

Add in:

- Google Analytics tracking on website
- GDPR compliant/University of Leeds regulation cookie consent
- Add in privacy and cookies policy

## What has been changed?

Adding in compliance with data privacy regulations, ensuring that our analytics are captured by cookie consent, allowing users to opt out.

## Other useful information

For reviewing, please compare https://comms.leeds.ac.uk/websites/policy-on-privacy-and-cookie-notices/ to the version I've added to the site, and check that we have captured everything required.

## Checklist

- [X] I've included all the commits I intended to in this PR 
- [X] I've built and tested this branch and there were no new warnings or errors 